### PR TITLE
Fix reordering-fractional-indices.mdx

### DIFF
--- a/content/posts/reordering-fractional-indices.mdx
+++ b/content/posts/reordering-fractional-indices.mdx
@@ -165,7 +165,7 @@ sendToBack(
 // }
 ```
 
-If we're putting items at the "top" of the list, then our `above` value will be `undefined§ and our `below`value will be the highest`index`among our items. Here we can simply iterate by incrementing the that`index`.
+If we're putting items at the "top" of the list, then our `above` value will be `undefined` and our `below`value will be the highest`index`among our items. Here we can simply iterate by incrementing the that`index`.
 
 ```ts
 getIndicesBetween(5, undefined, 1) // [6]


### PR DESCRIPTION
An ending code quote (`) was mistyped as a section sign (§), breaking the entire line formatting.